### PR TITLE
Fix Trying to access array offset on value of type null

### DIFF
--- a/lib/Horde/Date/Parser/Token.php
+++ b/lib/Horde/Date/Parser/Token.php
@@ -74,7 +74,7 @@ class Horde_Date_Parser_Token
             }
         );
         $match = array_shift($matches);
-        return $match[1];
+        return (is_array($match) ? $match[1] : null);
     }
 
     /**


### PR DESCRIPTION
With PHP 7.4.0RC4
```
$ phpunit
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

......EEEEEEEEEEEEEEEEEEEEEEEEEEEIEEEEEEEEEEEEEEEEEIEE.EEEE.EEEEE 65 / 71 ( 91%)
.....E                                                            71 / 71 (100%)

Time: 48 ms, Memory: 6,00MB

There were 56 errors:

1) Horde_Date_Parser_Locale_BaseTest::testTodayAt11
Trying to access array offset on value of type null

/work/GIT/horde/Date_Parser/lib/Horde/Date/Parser/Token.php:77
/work/GIT/horde/Date_Parser/lib/Horde/Date/Parser/Handler.php:47
/work/GIT/horde/Date_Parser/lib/Horde/Date/Parser/Locale/Base.php:320
/work/GIT/horde/Date_Parser/lib/Horde/Date/Parser/Locale/Base.php:130
/work/GIT/horde/Date_Parser/test/Horde/Date/Parser/Locale/BaseTest.php:26

....

Trying to access array offset on value of type null

/work/GIT/horde/Date_Parser/lib/Horde/Date/Parser/Token.php:77
/work/GIT/horde/Date_Parser/test/Horde/Date/Parser/TokenTest.php:58

ERRORS!
Tests: 71, Assertions: 36, Errors: 56, Incomplete: 2.

```